### PR TITLE
Log to the user visible log if Sturdy is not enabled for repo

### DIFF
--- a/src/lookup_repos.ts
+++ b/src/lookup_repos.ts
@@ -15,40 +15,47 @@ export interface FindReposResponse {
     repos: Array<SturdyRepository>;
 }
 
-export const LookupConnectedSturdyRepositories = async (git: SimpleGit, conf: Configuration): Promise<FindReposResponse | undefined> => {
-    console.log("lookup")
+export const LookupConnectedSturdyRepositories = async (git: SimpleGit, conf: Configuration): Promise<FindReposResponse | undefined> => {
+    let rawGitRemotes: string | void;
 
-    let rsp = await git.remote(["-v"]);
-    if (typeof rsp === "string") {
-        let remotes = new Map();
-
-        rsp.split("\n")
-            .filter((l: string) => l.length > 0)
-            .forEach((l: string) => {
-                let tokens = l.split("\t");
-                remotes.set(tokens[0], tokens[1].split(" ")[0]);
-            });
-
-        let out: { remote_name: string; remote_url: string }[] = [];
-        remotes.forEach((k: any, v: any) => {
-            out.push({ remote_name: v, remote_url: k });
-        });
-
-        let payload = { repos: out };
-
-        console.log("lookup", JSON.stringify(payload))
-
-        try {
-            const response = await axios.post<FindReposResponse>(conf.api + "/v3/conflicts/lookup",
-                payload,
-                { headers: headersWithAuth(conf.token) })
-            const res = response.data;
-            return res;
-        } catch (err) {
-            console.log("failed to match repositories", err);
-            return undefined;
-        }
+    try {
+        rawGitRemotes = await git.remote(["-v"]);
+    } catch (e) {
+        console.log("could not get remotes, this might not be a git repo", e);
+        return undefined;
     }
 
-    return Promise.reject(new Error('could not get remotes'));
+    if (!rawGitRemotes) {
+        console.log("could not get remotes");
+        return undefined;
+    }
+
+    let remotes = new Map();
+
+    rawGitRemotes.split("\n")
+        .filter((l: string) => l.length > 0)
+        .forEach((l: string) => {
+            let tokens = l.split("\t");
+            remotes.set(tokens[0], tokens[1].split(" ")[0]);
+        });
+
+    let out: { remote_name: string; remote_url: string }[] = [];
+    remotes.forEach((k: any, v: any) => {
+        out.push({ remote_name: v, remote_url: k });
+    });
+
+    let payload = { repos: out };
+
+    console.log("lookup", JSON.stringify(payload))
+
+    try {
+        const response = await axios.post<FindReposResponse>(conf.api + "/v3/conflicts/lookup",
+            payload,
+            { headers: headersWithAuth(conf.token) })
+        const res = response.data;
+        return res;
+    } catch (err) {
+        console.log("failed to match repositories", err);
+        return undefined;
+    }
 };

--- a/src/work.ts
+++ b/src/work.ts
@@ -51,10 +51,18 @@ export async function Work(publicLogs: vscode .OutputChannel) {
     publicLogs.appendLine("Welcome to Sturdy, " + user.name + "!");
 
     let repos : FindReposResponse | undefined;
+    let didLogAboutNotInstalled = false;
+
     for (;;) {
         repos = await LookupConnectedSturdyRepositories(git, conf);
         if (!repos || !repos.repos) {
             console.log("could not find any repos, waiting 30s before trying again")
+            
+            if (!didLogAboutNotInstalled) {
+                publicLogs.appendLine("Sturdy is not installed for any of the repositories in this Workspace. Go to https://getsturdy.com to set it up.")
+                didLogAboutNotInstalled = true;
+            }
+
             await new Promise((resolve) => setTimeout(resolve, 30000));
             continue;
         }


### PR DESCRIPTION
Simplified the logic in LookupConnectedSturdyRepositories and removed the usage of rejected promises (which we previously didn't catch).
Returning undefined for local git-errors, the same way that we return undefined if the API errors out.